### PR TITLE
Added createComment for post, getComments only for specific post, default ids

### DIFF
--- a/blog/lib/schema.js
+++ b/blog/lib/schema.js
@@ -1,3 +1,5 @@
+import uuid from 'uuid';
+
 import {
   GraphQLObjectType,
   GraphQLSchema,
@@ -10,7 +12,7 @@ import {
   GraphQLLimitedString
 } from 'graphql-custom-types';
 
-import { getPosts, getAuthor, getAuthors, getComments, createPost } from './dynamo';
+import { getPosts, getAuthor, getAuthors, getComments, createPost, createComment } from './dynamo';
 
 const Author = new GraphQLObjectType({
   name: "Author",
@@ -52,7 +54,7 @@ const Post = new GraphQLObjectType({
     comments: {
       type: new GraphQLList(Comment),
       resolve: function(post) {
-        return getComments();
+        return getComments(post.id);
       }
     }
   })
@@ -92,11 +94,30 @@ const Query = new GraphQLObjectType({
 const Mutuation = new GraphQLObjectType({
   name: 'BlogMutations',
   fields: {
+    createComment: {
+      type: Comment,
+      description: "Create blog comment",
+      args: {
+        id: {
+          type: GraphQLString,
+          defaultValue: uuid.v4()
+        },
+        postId: {type: new GraphQLNonNull(GraphQLString)},
+        content: {type: new GraphQLNonNull(GraphQLString)},
+        author: {type: new GraphQLNonNull(GraphQLString), description: "Id of the author"}
+      },
+      resolve: function(source, args) {
+        return createComment(args);
+      }
+    },
     createPost: {
       type: Post,
       description: "Create blog post",
       args: {
-        id: {type: new GraphQLNonNull(GraphQLString)},
+        id: {
+          type: GraphQLString,
+          defaultValue: uuid.v4()
+        },
         title: {type: new GraphQLLimitedString(10, 30)},
         bodyContent: {type: new GraphQLNonNull(GraphQLString)},
         author: {type: new GraphQLNonNull(GraphQLString), description: "Id of the author"}

--- a/blog/package.json
+++ b/blog/package.json
@@ -15,6 +15,7 @@
     "bluebird": "^3.1.1",
     "graphql": "^0.4.14",
     "graphql-custom-types": "^0.2.0",
-    "serverless-helpers-js": "~0.0.3"
+    "serverless-helpers-js": "~0.0.3",
+    "uuid": "2.0.2"
   }
 }


### PR DESCRIPTION
Hi

Wanted to play around a bit with aws lamdba, dynamoDB etc and used this as an example togheter with the serverless CLI, great job with the tool!

Implemented create and get comment just for testing, it all works fine so try it out and merge if you want to

Also added default id generation for posts and comments (got tired of making up new ids)

Simon
